### PR TITLE
Update readme

### DIFF
--- a/README.org
+++ b/README.org
@@ -1,1 +1,55 @@
 * yankee
+
+#+BEGIN_SRC markdown
+```emacs-lisp
+;; yankee.el L158-L163 (ea278931)
+
+(defun yankee/current-commit-ref ()
+  "The current commit's SHA, if under version control.
+Currently only supports Git."
+  (if (equal 'Git (vc-backend (buffer-file-name)))
+      (substring (shell-command-to-string "git rev-parse HEAD") 0 8)
+    nil))
+```
+<sup>
+  <a href="https://github.com/jkrmr/yankee/blob/ea278931/yankee.el#L158-L163">
+    yankee.el#L158-L163 (ea278931)
+  </a>
+</sup>
+#+END_SRC
+
+#+BEGIN_SRC markdown
+<details>
+<summary>yankee/current-commit-ref</summary>
+
+```emacs-lisp
+;; yankee.el L158-L163 (ea278931)
+
+(defun yankee/current-commit-ref ()
+  "The current commit's SHA, if under version control.
+Currently only supports Git."
+  (if (equal 'Git (vc-backend (buffer-file-name)))
+      (substring (shell-command-to-string "git rev-parse HEAD") 0 8)
+    nil))
+```
+<sup>
+  <a href=https://github.com/jkrmr/yankee/blob/ea278931/yankee.el#L158-L163">
+    yankee.el#L158-L163 (ea278931)
+  </a>
+</sup>
+</details>
+#+END_SRC
+
+#+BEGIN_SRC org
+#+BEGIN_SRC emacs-lisp
+;; yankee.el L158-L163 (ea278931)
+
+(defun yankee/current-commit-ref ()
+  "The current commit's SHA, if under version control.
+Currently only supports Git."
+  (if (equal 'Git (vc-backend (buffer-file-name)))
+      (substring (shell-command-to-string "git rev-parse HEAD") 0 8)
+    nil))
+#+END_SRC
+[[https://github.com/jkrmr/yankee/blob/ea278931/yankee.el#L158-L163][source]]
+#+END_SRC

--- a/README.org
+++ b/README.org
@@ -7,18 +7,23 @@ annotations to help readers gain more context:
 - ~yankee/yank-as-gfm-code-block-folded~
 - ~yankee/yank-as-org-code-block~
 
-Each yanks the selected code block and formats it appropriately: As
-GitHub-flavored Markdown, Foldable GFM, or an Org mode source block.
+These are especially useful when composing issues and pull/merge requests on
+GitHub / GitLab / Bitbucket, but have broader utility as well.
+
+Each yanks the selected code block and formats it as described by the function
+name: As GitHub-flavored Markdown, Foldable GFM, or an Org mode source block.
 
 If the file is in a project, its path relative to the project root will be used
 to annotate the code block with a comment including the selected line numbers.
 (If not in a project, an abbreviated absolute path will be included instead.)
 
-Additionally, if the buffer being yanked from is backed by a file under source
+Additionally, if the buffer being yanked from is backed by a file under version
 control, a commit ref will be included.
 
 And lastly, if a VCS remote named ~origin~ is found, a hyperlink to the
 selection, at the correct commit ref, will be included as well.
+
+Currently, only Git is supported, but contributions are welcome.
 
 ** GitHub-flavored Markdown
 
@@ -109,3 +114,17 @@ Currently only supports Git."
     nil))
 #+END_SRC
 [[https://github.com/jkrmr/yankee/blob/517300b3/yankee.el#L158-L163][yankee.el#L158-L163 (517300b3)]]
+
+** Demo
+
+** Installation
+
+To install, load yankee.el
+
+#+BEGIN_SRC emacs-lisp
+;; home/spacemacs.d/init.el L319-L320 (a1755783)
+
+  (load "yankee/yankee.el")
+  (require 'yankee)
+#+END_SRC
+[[https://github.com/jkrmr/dotfiles/blob/a1755783/home/spacemacs.d/init.el#L319-L320][home/spacemacs.d/init.el#L319-L320 (a1755783)]]

--- a/README.org
+++ b/README.org
@@ -10,8 +10,9 @@ annotations to help readers gain more context:
 These are especially useful when composing issues and pull/merge requests on
 GitHub / GitLab / Bitbucket, but have broader utility as well.
 
-Each yanks the selected code block and formats it as described by the function
-name: As GitHub-flavored Markdown, Foldable GFM, or an Org mode source block.
+Each function yanks the selected code block and formats it as described by the
+function name: As GitHub-flavored Markdown, Foldable GFM, or an Org mode source
+block.
 
 If the file is in a project, its path relative to the project root will be used
 to annotate the code block with a comment including the selected line numbers.

--- a/README.org
+++ b/README.org
@@ -126,7 +126,7 @@ Currently only supports Git."
 
 ** Installation
 
-  To install, load yankee.el and require ~\'yankee~ (the following assumes the
+  To install, load yankee.el and require ~yankee~ (the following assumes the
   project's parent directory has been added to the ~load-path~):
 
 #+BEGIN_SRC emacs-lisp

--- a/README.org
+++ b/README.org
@@ -18,22 +18,6 @@ Currently only supports Git."
 </sup>
 #+END_SRC
 
-```emacs-lisp
-;; yankee.el L158-L163 (ea278931)
-
-(defun yankee/current-commit-ref ()
-  "The current commit's SHA, if under version control.
-Currently only supports Git."
-  (if (equal 'Git (vc-backend (buffer-file-name)))
-      (substring (shell-command-to-string "git rev-parse HEAD") 0 8)
-    nil))
-```
-<sup>
-  <a href="https://github.com/jkrmr/yankee/blob/ea278931/yankee.el#L158-L163">
-    yankee.el#L158-L163 (ea278931)
-  </a>
-</sup>
-
 #+BEGIN_SRC markdown
 <details>
 <summary>yankee/current-commit-ref</summary>
@@ -56,41 +40,8 @@ Currently only supports Git."
 </details>
 #+END_SRC
 
-<details>
-<summary>yankee/current-commit-ref</summary>
-
-```emacs-lisp
-;; yankee.el L158-L163 (ea278931)
-
-(defun yankee/current-commit-ref ()
-  "The current commit's SHA, if under version control.
-Currently only supports Git."
-  (if (equal 'Git (vc-backend (buffer-file-name)))
-      (substring (shell-command-to-string "git rev-parse HEAD") 0 8)
-    nil))
-```
-<sup>
-  <a href=https://github.com/jkrmr/yankee/blob/ea278931/yankee.el#L158-L163">
-    yankee.el#L158-L163 (ea278931)
-  </a>
-</sup>
-</details>
-
 #+BEGIN_SRC org
-  #+BEGIN_SRC emacs-lisp
-  ;; yankee.el L158-L163 (ea278931)
-
-  (defun yankee/current-commit-ref ()
-    "The current commit's SHA, if under version control.
-  Currently only supports Git."
-    (if (equal 'Git (vc-backend (buffer-file-name)))
-        (substring (shell-command-to-string "git rev-parse HEAD") 0 8)
-      nil))
-  #+END_SRC
-  [[https://github.com/jkrmr/yankee/blob/ea278931/yankee.el#L158-L163][source]]
-#+END_SRC
-
-#+BEGIN_SRC emacs-lisp
+##+BEGIN_SRC emacs-lisp
 ;; yankee.el L158-L163 (ea278931)
 
 (defun yankee/current-commit-ref ()
@@ -99,5 +50,6 @@ Currently only supports Git."
   (if (equal 'Git (vc-backend (buffer-file-name)))
       (substring (shell-command-to-string "git rev-parse HEAD") 0 8)
     nil))
+##+END_SRC
+[ [https://github.com/jkrmr/yankee/blob/ea278931/yankee.el#L158-L163][source] ]
 #+END_SRC
-[[https://github.com/jkrmr/yankee/blob/ea278931/yankee.el#L158-L163][source]]

--- a/README.org
+++ b/README.org
@@ -41,8 +41,8 @@ Currently only supports Git."
 #+END_SRC
 
 #+BEGIN_SRC org
-##+BEGIN_SRC emacs-lisp
-;; yankee.el L158-L163 (ea278931)
+#+ BEGIN_SRC emacs-lisp
+;; yankee.el L158-L163 (517300b3)
 
 (defun yankee/current-commit-ref ()
   "The current commit's SHA, if under version control.
@@ -50,6 +50,18 @@ Currently only supports Git."
   (if (equal 'Git (vc-backend (buffer-file-name)))
       (substring (shell-command-to-string "git rev-parse HEAD") 0 8)
     nil))
-##+END_SRC
-[ [https://github.com/jkrmr/yankee/blob/ea278931/yankee.el#L158-L163][source] ]
+#+ END_SRC
+[[https://github.com/jkrmr/yankee/blob/517300b3/yankee.el#L158-L163] [yankee.el#L158-L163 (517300b3)]]
 #+END_SRC
+
+#+BEGIN_SRC emacs-lisp
+;; yankee.el L158-L163 (517300b3)
+
+(defun yankee/current-commit-ref ()
+  "The current commit's SHA, if under version control.
+Currently only supports Git."
+  (if (equal 'Git (vc-backend (buffer-file-name)))
+      (substring (shell-command-to-string "git rev-parse HEAD") 0 8)
+    nil))
+#+END_SRC
+[[https://github.com/jkrmr/yankee/blob/517300b3/yankee.el#L158-L163][yankee.el#L158-L163 (517300b3)]]

--- a/README.org
+++ b/README.org
@@ -126,7 +126,7 @@ Currently only supports Git."
 
 ** Installation
 
-  To install, load yankee.el and require ~'yankee~ (the following assumes the
+  To install, load yankee.el and require ~\'yankee~ (the following assumes the
   project's parent directory has been added to the ~load-path~):
 
 #+BEGIN_SRC emacs-lisp

--- a/README.org
+++ b/README.org
@@ -20,7 +20,7 @@ Currently only supports Git."
 </sup>
 #+END_SRC
 
-which produces
+which produces this [[https://github.com/jkrmr/yankee/pull/1#user-content-gfm][output]]:
 
 #+CAPTION: yank-as-gfm-code-block
 #+NAME: fig: gfm
@@ -52,7 +52,7 @@ Currently only supports Git."
 </details>
 #+END_SRC
 
-which produces
+which produces this [[https://github.com/jkrmr/yankee/pull/1#user-content-gfm-foldable][output]]:
 
 #+CAPTION: yank-as-gfm-code-block-foldable
 #+NAME: fig: gfm-foldable
@@ -76,7 +76,7 @@ Currently only supports Git."
 [[https://github.com/jkrmr/yankee/blob/517300b3/yankee.el#L158-L163] [yankee.el#L158-L163 (517300b3)]]
 #+END_SRC
 
-which produces
+which produces this output:
 
 #+BEGIN_SRC emacs-lisp
 ;; yankee.el L158-L163 (517300b3)

--- a/README.org
+++ b/README.org
@@ -1,5 +1,7 @@
 * yankee
 
+** GitHub-flavored Markdown
+
 #+BEGIN_SRC markdown
 ```emacs-lisp
 ;; yankee.el L158-L163 (ea278931)
@@ -17,6 +19,16 @@ Currently only supports Git."
   </a>
 </sup>
 #+END_SRC
+
+which produces
+
+#+CAPTION: yank-as-gfm-code-block
+#+NAME: fig: gfm
+https://cloud.githubusercontent.com/assets/4433943/26434857/271536bc-40d9-11e7-93f9-fe0988975259.png
+
+** GitHub-flavored Markdown (foldable)
+
+(The summary line is customizable at runtime)
 
 #+BEGIN_SRC markdown
 <details>
@@ -39,6 +51,14 @@ Currently only supports Git."
 </sup>
 </details>
 #+END_SRC
+
+which produces
+
+#+CAPTION: yank-as-gfm-code-block-foldable
+#+NAME: fig: gfm-foldable
+https://cloud.githubusercontent.com/assets/4433943/26434858/271fbf6a-40d9-11e7-91fb-66511c42cdc2.gif
+
+** Org mode
 
 #+BEGIN_SRC org
 #+ BEGIN_SRC emacs-lisp

--- a/README.org
+++ b/README.org
@@ -119,12 +119,27 @@ Currently only supports Git."
 
 ** Installation
 
-To install, load yankee.el
+  To install, load yankee.el (the following assumes the projectory's parent
+  directory has been added to the ~load-path~):
 
 #+BEGIN_SRC emacs-lisp
-;; home/spacemacs.d/init.el L319-L320 (a1755783)
+;; home/spacemacs.d/init.el L319-L320 (8b3c0dcd)
 
-  (load "yankee/yankee.el")
+  (load "yankee.el/yankee.el")
   (require 'yankee)
 #+END_SRC
-[[https://github.com/jkrmr/dotfiles/blob/a1755783/home/spacemacs.d/init.el#L319-L320][home/spacemacs.d/init.el#L319-L320 (a1755783)]]
+[[https://github.com/jkrmr/dotfiles/blob/8b3c0dcd/home/spacemacs.d/init.el#L319-L320][home/spacemacs.d/init.el#L319-L320 (8b3c0dcd)]]
+
+*** Suggested keybindings for evil-mode
+
+    Spacemacs and Evil-mode users may find the following key bindings intuitive:
+
+#+BEGIN_SRC emacs-lisp
+;; home/spacemacs.d/init.el L321-L324 (8b3c0dcd)
+
+  (define-key evil-visual-state-map (kbd "gy") nil)
+  (define-key evil-visual-state-map (kbd "gym") #'yankee/yank-as-gfm-code-block)
+  (define-key evil-visual-state-map (kbd "gyf") #'yankee/yank-as-gfm-code-block-folded)
+  (define-key evil-visual-state-map (kbd "gyo") #'yankee/yank-as-org-code-block)
+#+END_SRC
+[[https://github.com/jkrmr/dotfiles/blob/8b3c0dcd/home/spacemacs.d/init.el#L321-L324][home/spacemacs.d/init.el#L321-L324 (8b3c0dcd)]]

--- a/README.org
+++ b/README.org
@@ -24,7 +24,7 @@ which produces
 
 #+CAPTION: yank-as-gfm-code-block
 #+NAME: fig: gfm
-https://cloud.githubusercontent.com/assets/4433943/26434857/271536bc-40d9-11e7-93f9-fe0988975259.png
+[[https://cloud.githubusercontent.com/assets/4433943/26434857/271536bc-40d9-11e7-93f9-fe0988975259.png]]
 
 ** GitHub-flavored Markdown (foldable)
 
@@ -56,9 +56,11 @@ which produces
 
 #+CAPTION: yank-as-gfm-code-block-foldable
 #+NAME: fig: gfm-foldable
-https://cloud.githubusercontent.com/assets/4433943/26434858/271fbf6a-40d9-11e7-91fb-66511c42cdc2.gif
+[[https://cloud.githubusercontent.com/assets/4433943/26434858/271fbf6a-40d9-11e7-91fb-66511c42cdc2.gif]]
 
 ** Org mode
+
+(Intentionally broken here)
 
 #+BEGIN_SRC org
 #+ BEGIN_SRC emacs-lisp
@@ -73,6 +75,8 @@ Currently only supports Git."
 #+ END_SRC
 [[https://github.com/jkrmr/yankee/blob/517300b3/yankee.el#L158-L163] [yankee.el#L158-L163 (517300b3)]]
 #+END_SRC
+
+which produces
 
 #+BEGIN_SRC emacs-lisp
 ;; yankee.el L158-L163 (517300b3)

--- a/README.org
+++ b/README.org
@@ -118,6 +118,10 @@ Currently only supports Git."
 
 ** Demo
 
+#+CAPTION: yankee.el demo
+#+NAME: fig: yankee-demo
+[[https://cloud.githubusercontent.com/assets/4433943/26436253/2afd53f4-40e3-11e7-9791-b671042755d4.gif]]
+
 ** Installation
 
   To install, load yankee.el (the following assumes the project's parent

--- a/README.org
+++ b/README.org
@@ -119,7 +119,7 @@ Currently only supports Git."
 
 ** Installation
 
-  To install, load yankee.el (the following assumes the projectory's parent
+  To install, load yankee.el (the following assumes the project's parent
   directory has been added to the ~load-path~):
 
 #+BEGIN_SRC emacs-lisp

--- a/README.org
+++ b/README.org
@@ -126,8 +126,8 @@ Currently only supports Git."
 
 ** Installation
 
-  To install, load yankee.el (the following assumes the project's parent
-  directory has been added to the ~load-path~):
+  To install, load yankee.el and require ~'yankee~ (the following assumes the
+  project's parent directory has been added to the ~load-path~):
 
 #+BEGIN_SRC emacs-lisp
 ;; home/spacemacs.d/init.el L319-L320 (8b3c0dcd)

--- a/README.org
+++ b/README.org
@@ -118,6 +118,8 @@ Currently only supports Git."
 
 ** Demo
 
+(Click to view animated)
+
 #+CAPTION: yankee.el demo
 #+NAME: fig: yankee-demo
 [[https://cloud.githubusercontent.com/assets/4433943/26436253/2afd53f4-40e3-11e7-9791-b671042755d4.gif]]

--- a/README.org
+++ b/README.org
@@ -1,4 +1,24 @@
-* yankee
+* yankee.el
+
+Yankee provides functions for yanking source blocks in Emacs with some helpful
+annotations to help readers gain more context:
+
+- ~yankee/yank-as-gfm-code-block~
+- ~yankee/yank-as-gfm-code-block-folded~
+- ~yankee/yank-as-org-code-block~
+
+Each yanks the selected code block and formats it appropriately: As
+GitHub-flavored Markdown, Foldable GFM, or an Org mode source block.
+
+If the file is in a project, its path relative to the project root will be used
+to annotate the code block with a comment including the selected line numbers.
+(If not in a project, an abbreviated absolute path will be included instead.)
+
+Additionally, if the buffer being yanked from is backed by a file under source
+control, a commit ref will be included.
+
+And lastly, if a VCS remote named ~origin~ is found, a hyperlink to the
+selection, at the correct commit ref, will be included as well.
 
 ** GitHub-flavored Markdown
 
@@ -60,7 +80,7 @@ which produces this [[https://github.com/jkrmr/yankee/pull/1#user-content-gfm-fo
 
 ** Org mode
 
-(Intentionally broken here)
+(Intentionally broken here so the raw syntax will render)
 
 #+BEGIN_SRC org
 #+ BEGIN_SRC emacs-lisp

--- a/README.org
+++ b/README.org
@@ -18,6 +18,22 @@ Currently only supports Git."
 </sup>
 #+END_SRC
 
+```emacs-lisp
+;; yankee.el L158-L163 (ea278931)
+
+(defun yankee/current-commit-ref ()
+  "The current commit's SHA, if under version control.
+Currently only supports Git."
+  (if (equal 'Git (vc-backend (buffer-file-name)))
+      (substring (shell-command-to-string "git rev-parse HEAD") 0 8)
+    nil))
+```
+<sup>
+  <a href="https://github.com/jkrmr/yankee/blob/ea278931/yankee.el#L158-L163">
+    yankee.el#L158-L163 (ea278931)
+  </a>
+</sup>
+
 #+BEGIN_SRC markdown
 <details>
 <summary>yankee/current-commit-ref</summary>
@@ -40,7 +56,40 @@ Currently only supports Git."
 </details>
 #+END_SRC
 
+<details>
+<summary>yankee/current-commit-ref</summary>
+
+```emacs-lisp
+;; yankee.el L158-L163 (ea278931)
+
+(defun yankee/current-commit-ref ()
+  "The current commit's SHA, if under version control.
+Currently only supports Git."
+  (if (equal 'Git (vc-backend (buffer-file-name)))
+      (substring (shell-command-to-string "git rev-parse HEAD") 0 8)
+    nil))
+```
+<sup>
+  <a href=https://github.com/jkrmr/yankee/blob/ea278931/yankee.el#L158-L163">
+    yankee.el#L158-L163 (ea278931)
+  </a>
+</sup>
+</details>
+
 #+BEGIN_SRC org
+  #+BEGIN_SRC emacs-lisp
+  ;; yankee.el L158-L163 (ea278931)
+
+  (defun yankee/current-commit-ref ()
+    "The current commit's SHA, if under version control.
+  Currently only supports Git."
+    (if (equal 'Git (vc-backend (buffer-file-name)))
+        (substring (shell-command-to-string "git rev-parse HEAD") 0 8)
+      nil))
+  #+END_SRC
+  [[https://github.com/jkrmr/yankee/blob/ea278931/yankee.el#L158-L163][source]]
+#+END_SRC
+
 #+BEGIN_SRC emacs-lisp
 ;; yankee.el L158-L163 (ea278931)
 
@@ -52,4 +101,3 @@ Currently only supports Git."
     nil))
 #+END_SRC
 [[https://github.com/jkrmr/yankee/blob/ea278931/yankee.el#L158-L163][source]]
-#+END_SRC

--- a/yankee.el
+++ b/yankee.el
@@ -152,7 +152,7 @@ Includes a filename comment annotation."
           ((equal format 'gfm-folded)
            (yankee/gfm-code-fence-folded language-mode selected-lines snippet-path snippet-url))
           ((equal format 'org)
-           (yankee/org-code-fence language-mode selected-lines snippet-url)))
+           (yankee/org-code-fence language-mode selected-lines snippet-path snippet-url)))
     (clipboard-kill-ring-save (point-min) (point-max))))
 
 (defun yankee/current-commit-ref ()
@@ -211,13 +211,13 @@ Includes a filename comment annotation."
   (and url (insert (format "<sup>\n  <a href=%s\">\n    %s\n  </a>\n</sup>\n" url path)))
   (insert "</details>"))
 
-(defun yankee/org-code-fence (language code url)
-  "Create an Org code block with LANGUAGE annotation containing CODE and URL."
+(defun yankee/org-code-fence (language code path url)
+  "Create an Org code block with LANGUAGE annotation containing CODE, PATH, and URL."
   (goto-char (point-min))
   (insert "#+BEGIN_SRC" " " language "\n")
   (goto-char (point-max))
   (insert "\n\n" code "#+END_SRC\n")
-  (and url (insert (format "[[%s][source]]" url))))
+  (and url (insert (format "[[%s][%s]]" url path))))
 
 (defun yankee/code-snippet-url (commit-remote commit-ref file-name selection-range)
   "Generate the snippet url from COMMIT-REMOTE, COMMIT-REF, FILE-NAME, and the SELECTION-RANGE."


### PR DESCRIPTION
 <a id="gfm">

GFM output
=========

```emacs-lisp
;; yankee.el L158-L163 (ea278931)

(defun yankee/current-commit-ref ()
  "The current commit's SHA, if under version control.
Currently only supports Git."
  (if (equal 'Git (vc-backend (buffer-file-name)))
      (substring (shell-command-to-string "git rev-parse HEAD") 0 8)
    nil))
```
<sup>
  <a href="https://github.com/jkrmr/yankee/blob/ea278931/yankee.el#L158-L163">
    yankee.el#L158-L163 (ea278931)
  </a>
</sup>

-----------------

<img width="792" alt="gfm" src="https://cloud.githubusercontent.com/assets/4433943/26434857/271536bc-40d9-11e7-93f9-fe0988975259.png">

<a id="gfm-foldable">

GFM-foldable output 
===============

<details>
  <summary>the current commit ref function</summary>

```emacs-lisp
;; yankee.el L158-L163 (11feaaf1)

(defun yankee/current-commit-ref ()
  "The current commit's SHA, if under version control.
Currently only supports Git."
  (if (equal 'Git (vc-backend (buffer-file-name)))
      (substring (shell-command-to-string "git rev-parse HEAD") 0 8)
    nil))
```
<sup>
  <a href=https://github.com/jkrmr/yankee/blob/11feaaf1/yankee.el#L158-L163">
    yankee.el#L158-L163 (11feaaf1)
  </a>
</sup>
</details>

-------------------

![gfm-foldable](https://cloud.githubusercontent.com/assets/4433943/26434858/271fbf6a-40d9-11e7-91fb-66511c42cdc2.gif)
