### PR TITLE
Add Tuareg mode support

### DIFF
--- a/yankee.el
+++ b/yankee.el
@@ -133,7 +133,15 @@ Includes a filename comment annotation."
          (snippet-url (yankee--code-snippet-url (yankee--current-commit-remote)
                                                 commit-ref
                                                 file-name
-                                                selection-range)))
+                                                selection-range))
+         ;; Example: in tuareg-mode, 'tuareg-mode-hook' variable, as a symbol
+         (mode-hook-atom (intern (format "%s-hook" mode-string)))
+         ;; Store any mode hooks
+         (original-mode-hooks (format "%s" (eval `,mode-hook-atom))))
+
+    ;; disable any major mode hooks for the current mode
+    (eval `(setq ,mode-hook-atom nil))
+
     (with-temp-buffer
       (funcall mode-atom)
       (insert file-name " " selection-range
@@ -146,7 +154,10 @@ Includes a filename comment annotation."
              (yankee--gfm-code-fence-folded language-mode selected-lines snippet-path snippet-url))
             ((equal format 'org)
              (yankee--org-code-fence language-mode selected-lines snippet-path snippet-url)))
-      (clipboard-kill-ring-save (point-min) (point-max)))))
+      (clipboard-kill-ring-save (point-min) (point-max)))
+
+    ;; re-enable the current major mode's hooks
+    (eval `(setq ,mode-hook-atom ,original-mode-hooks))))
 
 (defun yankee--current-buffer-language (mode-string)
   "The language used in the current buffer, extracted from the major MODE-STRING.

--- a/yankee.el
+++ b/yankee.el
@@ -122,13 +122,11 @@ Includes a filename comment annotation."
          ;; The current buffer's major mode.
          (mode-name (buffer-local-value 'major-mode (current-buffer)))
          ;; The current buffer's major mode as a string.
-         (mode-string (format "%s" (or mode-name "")))
+         (mode-string (format "%s" (or mode-name "text")))
          ;; The current buffer's major mode as an atom.
          (mode-atom (intern mode-string))
          ;; The language, as derived from the major mode.
-         (language-mode (replace-regexp-in-string "-mode$" "" mode-string))
-         ;; The language, taken from the file extension.
-         ;; (language-extension (or (file-name-extension (or (buffer-file-name) "")) "text"))
+         (language-mode (yankee--current-buffer-language mode-string))
          ;; A path for the selected code, including line numbers and SHA.
          (snippet-path (yankee--code-snippet-path commit-ref file-name selection-range))
          ;; A URL for the selected code, if a remote version exists.
@@ -149,6 +147,14 @@ Includes a filename comment annotation."
             ((equal format 'org)
              (yankee--org-code-fence language-mode selected-lines snippet-path snippet-url)))
       (clipboard-kill-ring-save (point-min) (point-max)))))
+
+(defun yankee--current-buffer-language (mode-string)
+  "The language used in the current buffer, extracted from the major MODE-STRING.
+Intended for use in code block. Corner cases are mapped to strings GFM / Org can
+understand."
+  (let ((language (replace-regexp-in-string "-mode$" "" mode-string)))
+    (cond ((equal language "tuareg") "ocaml")
+          (t language))))
 
 (defun yankee--current-commit-ref ()
   "The current commit's SHA, if under version control.

--- a/yankee.el
+++ b/yankee.el
@@ -111,7 +111,6 @@ If not in a project, the path is an abbreviated absolute path."
 Includes a filename comment annotation."
   (interactive "r")
 
-
   (let* (;; The current buffer's file name.
          (file-name (yankee--abbreviated-project-or-home-path-to-file))
          ;; The current commit reference, if under version control.


### PR DESCRIPTION
Tuareg mode has a hook that raises an exception in a temporary buffer and prevents yanking from OCaml files. To work around this problem, temporarily disable major mode hooks before beginning work in the temporary buffer, then, after the temp buffer's contents have been copied to the pasteboard, re-set the major mode's hook variable to its original value.

Example output after changes:

```ocaml
(* ocaml/hello-world/test.ml L4-L5 (af7019de) *)

open OUnit2
open Hello_world
```
<sup>
  <a href="https://github.com/jkrmr/exercism/blob/af7019de/ocaml/hello-world/test.ml#L4-L5">
    ocaml/hello-world/test.ml#L4-L5 (af7019de)
  </a>
</sup>


```emacs-lisp
;; yankee.el L142-L160 (2bbba636)

    ;; disable any major mode hooks for the current mode
    (eval `(setq ,mode-hook-atom nil))

    (with-temp-buffer
      (funcall mode-atom)
      (insert file-name " " selection-range
              (if commit-ref (format " (%s)" commit-ref) ""))
      (comment-or-uncomment-region (line-beginning-position) (line-end-position))

      (cond ((equal format 'gfm)
             (yankee--gfm-code-fence language-mode selected-lines snippet-path snippet-url))
            ((equal format 'gfm-folded)
             (yankee--gfm-code-fence-folded language-mode selected-lines snippet-path snippet-url))
            ((equal format 'org)
             (yankee--org-code-fence language-mode selected-lines snippet-path snippet-url)))
      (clipboard-kill-ring-save (point-min) (point-max)))

    ;; re-enable the current major mode's hooks
    (eval `(setq ,mode-hook-atom ,original-mode-hooks))))
```
<sup>
  <a href="https://github.com/jkrmr/yankee.el/blob/2bbba636/yankee.el#L142-L160">
    yankee.el#L142-L160 (2bbba636)
  </a>
</sup>
